### PR TITLE
FIX: Require environment variable to use DataLad

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ jobs:
             pyenv global 3.5.2
             virtualenv venv
             pip install -r /tmp/src/templateflow/requirements.txt
+            pip install datalad
             pip install "setuptools>=27.0" twine
 
       - save_cache:
@@ -48,6 +49,9 @@ jobs:
 
       - run:
           name: Run tests (w/o datalad)
+          environment:
+            TEMPLATEFLOW_USE_DATALAD: 0
+            TEMPLATEFLOW_HOME: "/tmp/data/templateflow"
           command: |
             pyenv global 3.5.2
             virtualenv venv
@@ -56,20 +60,22 @@ jobs:
 
       - run:
           name: Run tests (pulling from S3)
+          environment:
+            TEMPLATEFLOW_USE_DATALAD: 0
+            TEMPLATEFLOW_HOME: "/tmp/data/templateflow-S3"
           command: |
             pyenv global 3.5.2
             virtualenv venv
-            export TEMPLATEFLOW_HOME="/tmp/data/templateflow-S3"
             pytest -vsx --doctest-modules /tmp/src/templateflow/templateflow
 
       - run:
           name: Run tests (w/ datalad)
+          environment:
+            TEMPLATEFLOW_USE_DATALAD: 1
           command: |
             unset TEMPLATEFLOW_HOME
-            export TEMPLATEFLOW_USE_DATALAD=true
             pyenv global 3.5.2
             virtualenv venv
-            pip install datalad
             pytest -vsx --doctest-modules /tmp/src/templateflow/templateflow
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,7 @@ jobs:
           name: Run tests (w/ datalad)
           command: |
             unset TEMPLATEFLOW_HOME
+            export TEMPLATEFLOW_USE_DATALAD=true
             pyenv global 3.5.2
             virtualenv venv
             pip install datalad

--- a/templateflow/conf/__init__.py
+++ b/templateflow/conf/__init__.py
@@ -11,26 +11,31 @@ TF_DEFAULT_HOME = Path.home() / '.cache' / 'templateflow'
 TF_HOME = Path(getenv('TEMPLATEFLOW_HOME', str(TF_DEFAULT_HOME)))
 TF_GITHUB_SOURCE = 'https://github.com/templateflow/templateflow.git'
 TF_S3_ROOT = 'https://templateflow.s3.amazonaws.com'
+TF_USE_DATALAD = getenv('TEMPLATEFLOW_USE_DATALAD', 'false').lower() in (
+    'true', 'on', '1')
 
 _msg = """\
 TemplateFlow: repository not found at %s. Populating a TemplateFlow stub.
-If the path reported above is not the desired location for Templateflow, \
+If the path reported above is not the desired location for TemplateFlow, \
 please set the TEMPLATEFLOW_HOME environment variable.
 """ % TF_HOME
 
 if not TF_HOME.exists() or not list(TF_HOME.iterdir()):
     warn(_msg, ResourceWarning)
-    try:
-        from datalad.api import install
-    except ImportError:
+    if TF_USE_DATALAD:
+        try:
+            from datalad.api import install
+        except ImportError:
+            TF_USE_DATALAD = False
+            TF_HOME.parent.mkdir(exist_ok=True, parents=True)
+            install(path=str(TF_HOME), source=TF_GITHUB_SOURCE, recursive=True)
+
+    if not TF_USE_DATALAD:
         from zipfile import ZipFile
         TF_HOME.mkdir(exist_ok=True, parents=True)
         with ZipFile(resource_filename('templateflow',
                                        'conf/templateflow-skel.zip'), 'r') as zipref:
             zipref.extractall(str(TF_HOME))
-    else:
-        TF_HOME.parent.mkdir(exist_ok=True, parents=True)
-        install(path=str(TF_HOME), source=TF_GITHUB_SOURCE, recursive=True)
 
 TF_LAYOUT = Layout(
     TF_HOME, validate=False, config='templateflow',

--- a/templateflow/conf/__init__.py
+++ b/templateflow/conf/__init__.py
@@ -27,6 +27,7 @@ if not TF_HOME.exists() or not list(TF_HOME.iterdir()):
             from datalad.api import install
         except ImportError:
             TF_USE_DATALAD = False
+        else:
             TF_HOME.parent.mkdir(exist_ok=True, parents=True)
             install(path=str(TF_HOME), source=TF_GITHUB_SOURCE, recursive=True)
 


### PR DESCRIPTION
This PR adds a check on ``TEMPLATEFLOW_USE_DATALAD`` (default unset
or false) which needs to evaluate to ``True`` in order to use
DataLad.

This fix addresses poldracklab/fmriprep#1534.