### PR TITLE
FIX: Add extension entity for selection

### DIFF
--- a/templateflow/conf/config.json
+++ b/templateflow/conf/config.json
@@ -66,6 +66,10 @@
         {
             "name": "description",
             "pattern": "(.*\\template_description.json)$"
+        },
+        {
+            "name": "extension",
+            "pattern": "[._]*[a-zA-Z0-9]*?\\.([^/\\\\]+)$"
         }
     ],
     "default_path_patterns": [


### PR DESCRIPTION
Should probably also upgrade to pybids 0.9.2 after bids-standard/pybids#458 goes in.