### PR TITLE
MAINT: Transfer the burden of keeping skeleton updated over to the archive

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,55 +70,6 @@ jobs:
             - "/tmp/venv"
 
       - run:
-          name: Update TemplateFlow skeleton
-          command: |
-            source /tmp/venv/bin/activate
-            datalad install -r -s  https://github.com/templateflow/templateflow $HOME/.cache/templateflow
-            cd $HOME/.cache/templateflow/
-            find . -type d -not -path "*/\.*" -exec mkdir -p /tmp/skel/{} \;
-            for i in $( find . -type f -not -path "*/\.*" ); do cp $i /tmp/skel/${i:2}; done
-            find . -type l -not -path "*/\.*" -exec touch /tmp/skel/{} \;
-            cd /tmp/skel
-            mkdir -p /tmp/resources
-            zip -r /tmp/resources/templateflow-skel.zip */
-            find . -type f -exec md5sum {} \; | sort -k 2 | md5sum > /tmp/resources/templateflow-skel.md5
-
-      - store_artifacts:
-          path: /tmp/resources/templateflow-skel.zip
-
-      - restore_cache:
-          keys:
-            - osf-v1-{{ .Branch }}-{{ .Revision }}
-            - osf-v1-{{ .Branch }}-
-            - osf-v1-master
-            - osf-v1-
-          paths:
-            - /tmp/data/templateflow
-      - run:
-          name: Check whether OSF cache needs update
-          command: |
-            if [[ -d "${OSF_MIRROR_PATH}" ]]; then
-              if cmp --silent /tmp/resources/templateflow-skel.md5 /tmp/src/templateflow/templateflow/conf/templateflow-skel.md5; then
-                  echo "Skeleton has not changed"
-              else
-                  echo "OSF mirror needs update"
-                  rm -rf ${OSF_MIRROR_PATH}
-              fi
-            fi
-      - run:
-          name: Get TemplateFlow Zip package
-          command: |
-            if [[ ! -d "${OSF_MIRROR_PATH}" ]]; then
-              mkdir -p ${OSF_MIRROR_PATH}
-              curl "https://files.osf.io/v1/resources/ue5gx/providers/osfstorage/?zip=" -o templateflow.zip
-              unzip templateflow.zip -d ${OSF_MIRROR_PATH}
-            fi
-      - save_cache:
-          key: osf-v1-{{ .Branch }}-{{ .Revision }}
-          paths:
-            - /tmp/data/templateflow
-
-      - run:
           name: Run tests (w/ DataLad)
           command: |
             source /tmp/venv/bin/activate
@@ -134,28 +85,11 @@ jobs:
                 --flags api,datalad -e CIRCLE_JOB
 
       - run:
-          name: Run tests (pre-cached full TemplateFlow / no downloads)
-          command: |
-            source /tmp/venv/bin/activate
-            export TEMPLATEFLOW_HOME="${OSF_MIRROR_PATH}"
-            pytest --junit-xml=/tmp/tests/wodatalad.xml --cov templateflow --cov-report xml:/tmp/cov_api_cached.xml \
-                   --doctest-modules /tmp/src/templateflow/templateflow/api.py
-
-      - run:
-          name: Submit api test coverage
-          command: |
-            source /tmp/venv/bin/activate
-            codecov --file /tmp/cov_api_cached.xml --root /tmp/src/templateflow \
-                --flags api,cached -e CIRCLE_JOB
-
-      - run:
           name: Run tests (pulling from S3)
           command: |
             source /tmp/venv/bin/activate
             export TEMPLATEFLOW_USE_DATALAD=off
             export TEMPLATEFLOW_HOME=$HOME/templateflow-s3
-            # Make sure we use an updated skeleton
-            cp /tmp/resources/templateflow-skel.{zip,md5} /tmp/src/templateflow/templateflow/conf/
             pytest --junit-xml=/tmp/tests/s3.xml --cov templateflow --cov-report xml:/tmp/cov_api_s3.xml \
                    --doctest-modules /tmp/src/templateflow/templateflow/api.py
 
@@ -207,11 +141,6 @@ jobs:
             cd /tmp/src/templateflow
             python setup.py sdist
             twine check dist/*
-
-      - persist_to_workspace:
-          root: /tmp
-          paths:
-            - resources
 
   build_docs:
     docker:
@@ -265,61 +194,6 @@ jobs:
       - store_artifacts:
           path: ./docs/_build/html
 
-  update_skel:
-    machine:
-      image: circleci/classic:201711-01
-    working_directory: /tmp/src/templateflow
-    steps:
-      - attach_workspace:
-          at: /tmp
-
-      - checkout:
-          path: /tmp/src/templateflow
-
-      - restore_cache:
-          keys:
-            - deps-v9-{{ checksum "/tmp/src/templateflow/requirements.txt"}}-{{ epoch }}
-            - deps-v9-{{ checksum "/tmp/src/templateflow/requirements.txt"}}-
-            - deps-v9-
-
-      - add_ssh_keys:
-          fingerprints:
-            - "ae:95:0c:cc:09:84:64:99:92:82:b7:b5:f4:a7:e9:23"
-
-      - run:
-          name: Checkout origin/master
-          command: |
-            git config user.email "${GITHUB_EMAIL}"
-            git config user.name "CircleCI Deploy"
-            git fetch origin
-            git checkout -f origin/master
-
-      - run:
-          name: Update CHANGES if this is a merge commit
-          command: |
-            if (( $( git cat-file -p HEAD | sed -n '/^parent [0-9a-f]*$/p' | wc -l ) > 1 )); then
-              bash update_changes.sh
-              git add CHANGES.rst
-              git commit -m "auto: Update CHANGES [skip ci]"
-              git push origin HEAD:master
-            fi
-
-      - run:
-          name: Check whether skeleton needs an update
-          command: |
-            if cmp --silent /tmp/resources/templateflow-skel.md5 /tmp/src/templateflow/templateflow/conf/templateflow-skel.md5; then
-                echo "S3 Skeleton has not changed"
-                circleci step halt
-            fi
-
-      - run:
-          name: Push skeleton back to TemplateFlow's client repo
-          command: |
-            cp /tmp/resources/templateflow-skel.{zip,md5} templateflow/conf/
-            git add templateflow/conf/templateflow-skel.{zip,md5}
-            git commit -m "auto: Update S3 skeleton file and checksum [skip ci]"
-            git push origin HEAD:master
-
   deploy_pypi:
     docker:
       - image: circleci/python:3.7.6
@@ -371,14 +245,6 @@ workflows:
               ignore: /.*/
             tags:
               only: /.*/
-      - update_skel:
-          requires:
-            - tests
-          filters:
-            branches:
-              only: /master/
-            tags:
-              ignore: /.*/
 
       - build_docs:
           filters:
@@ -391,7 +257,6 @@ workflows:
       - deploy_docs_master:
           requires:
             - tests
-            - update_skel
             - build_docs
           filters:
             branches:
@@ -419,7 +284,3 @@ workflows:
                 - master
     jobs:
       - tests
-      - update_skel:
-          requires:
-            - tests
-


### PR DESCRIPTION
Drops all the CI mechanisms to manage the skeleton. This means, for instance, we do not need to force another build of master before every release just to be sure the skeleton is updated.

Resolves: #38