### PR TITLE
BF: provide path to the dataset as "dataset" argument

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ exclude =
 citations =
     doi2bib
 datalad =
-    datalad ~= 0.11.8
+    datalad ~= 0.12.0
 doc =
     nbsphinx
     packaging

--- a/templateflow/conf/__init__.py
+++ b/templateflow/conf/__init__.py
@@ -69,7 +69,7 @@ def _update_datalad():
 
     print("Updating TEMPLATEFLOW_HOME using DataLad ...")
     try:
-        update(str(TF_HOME), recursive=True, merge=True)
+        update(dataset=str(TF_HOME), recursive=True, merge=True)
     except Exception as e:
         warn(f"Error updating TemplateFlow's home directory (using DataLad): {e}")
     return True


### PR DESCRIPTION
this is due to the change in behavior of 0.12.x series of DataLad.
See https://github.com/datalad/datalad/issues/3759
for more info

Closes #47 
Disclaimer: I have not tried the fix anyhow