### PR TITLE
[FIX] Make download progress bar display correct units

### DIFF
--- a/templateflow/api.py
+++ b/templateflow/api.py
@@ -209,7 +209,6 @@ def _datalad_get(filepath):
 
 def _s3_get(filepath):
     from sys import stderr
-    from math import ceil
     from tqdm import tqdm
     import requests
 
@@ -228,14 +227,12 @@ def _s3_get(filepath):
         filepath.unlink()
 
     with filepath.open("wb") as f:
-        for data in tqdm(
-            r.iter_content(block_size),
-            total=ceil(total_size // block_size),
-            unit="B",
-            unit_scale=True,
-        ):
-            wrote = wrote + len(data)
-            f.write(data)
+        with tqdm(total=total_size, unit="B", unit_scale=True) as t:
+            for data in r.iter_content(block_size):
+                wrote = wrote + len(data)
+                f.write(data)
+                t.update(len(data))
+
     if total_size != 0 and wrote != total_size:
         raise RuntimeError("ERROR, something went wrong")
 


### PR DESCRIPTION
When downloading files, the progress display shows file sizes on the order of kilobytes, even though the requested file should be multiple megabytes in size. When I first encountered this, I thought the files may be corrupt, but this is not the case.
```
Downloading https://templateflow.s3.amazonaws.com/tpl-MNI152NLin2009cAsym/tpl-MNI152NLin2009cAsym_res-01_desc-brain_T1w.nii.gz
3.39kB [00:00, 3.46kB/s]
```

Steps to reproduce this
```
import os
from tempfile import mkdtemp
os.environ["TEMPLATEFLOW_HOME"] = mkdtemp()

from templateflow import api
api.get("MNI152NLin2009cAsym", resolution=1, desc="brain", suffix="T1w")
```

Looking at the code, I discovered that the progress bar module `tqdm` is configured to display one download block as one byte, even though one download block can be up to 1024 bytes in size. 

With the proposed fix, the correct file size is displayed
```
Downloading https://templateflow.s3.amazonaws.com/tpl-MNI152NLin2009cAsym/tpl-MNI152NLin2009cAsym_res-01_desc-brain_T1w.nii.gz
100%|████████████████████████████████████████████████████████████| 3.47M/3.47M [00:01<00:00, 3.46MB/s]
```