### PR TITLE
FIX: Remove GH Action set-env

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -54,7 +54,7 @@ jobs:
         THISVERSION=$( python setup.py --version )
         THISVERSION=${TAG:-$THISVERSION}
         echo "Expected VERSION: \"${THISVERSION}\""
-        echo ::set-env name=THISVERSION::"${THISVERSION}"
+        echo "THISVERSION=${THISVERSION}" >> $GITHUB_ENV
 
     - name: Install in confined environment [pip]
       env:


### PR DESCRIPTION
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/