### PR TITLE
FIX: layout is ``None`` when PyBIDS not correctly installed

### DIFF
--- a/templateflow/api.py
+++ b/templateflow/api.py
@@ -4,9 +4,10 @@ from pathlib import Path
 import re
 import sys
 
-from .conf import TF_LAYOUT, TF_S3_ROOT, TF_USE_DATALAD
+from .conf import TF_LAYOUT, TF_S3_ROOT, TF_USE_DATALAD, requires_layout
 
 
+@requires_layout
 def get(template, raise_empty=False, **kwargs):
     """
     Fetch one file from one particular template.
@@ -61,10 +62,6 @@ def get(template, raise_empty=False, **kwargs):
     ...
 
     """
-    if TF_LAYOUT is None:
-        from bids import __version__
-        raise RuntimeError(f"A layout with PyBIDS <{__version__}> could not be initiated")
-
     out_file = [
         Path(p) for p in TF_LAYOUT.get(template=template, return_type="file", **kwargs)
     ]
@@ -115,9 +112,10 @@ off (possible values: false, off, 0)."""
     return out_file
 
 
+@requires_layout
 def templates(**kwargs):
     """
-    Returns a list of available templates.
+    Return a list of available templates.
 
     Keyword Arguments
     -----------------
@@ -141,13 +139,10 @@ def templates(**kwargs):
     ['MNI152Lin', 'MNI152NLin2009cAsym', 'MNI152NLin2009cSym', 'MNIInfant', 'MNIPediatricAsym']
 
     """
-    if TF_LAYOUT is None:
-        from bids import __version__
-        raise RuntimeError(f"A layout with PyBIDS <{__version__}> could not be initiated")
-
     return sorted(TF_LAYOUT.get_templates(**kwargs))
 
 
+@requires_layout
 def get_metadata(template):
     """
     Fetch one file from one template.
@@ -163,10 +158,6 @@ def get_metadata(template):
     'Linear ICBM Average Brain (ICBM152) Stereotaxic Registration Model'
 
     """
-    if TF_LAYOUT is None:
-        from bids import __version__
-        raise RuntimeError(f"A layout with PyBIDS <{__version__}> could not be initiated")
-
     tf_home = Path(TF_LAYOUT.root)
     filepath = tf_home / ("tpl-%s" % template) / "template_description.json"
 

--- a/templateflow/api.py
+++ b/templateflow/api.py
@@ -61,6 +61,10 @@ def get(template, raise_empty=False, **kwargs):
     ...
 
     """
+    if TF_LAYOUT is None:
+        from bids import __version__
+        raise RuntimeError(f"A layout with PyBIDS <{__version__}> could not be initiated")
+
     out_file = [
         Path(p) for p in TF_LAYOUT.get(template=template, return_type="file", **kwargs)
     ]
@@ -137,6 +141,10 @@ def templates(**kwargs):
     ['MNI152Lin', 'MNI152NLin2009cAsym', 'MNI152NLin2009cSym', 'MNIInfant', 'MNIPediatricAsym']
 
     """
+    if TF_LAYOUT is None:
+        from bids import __version__
+        raise RuntimeError(f"A layout with PyBIDS <{__version__}> could not be initiated")
+
     return sorted(TF_LAYOUT.get_templates(**kwargs))
 
 
@@ -155,6 +163,9 @@ def get_metadata(template):
     'Linear ICBM Average Brain (ICBM152) Stereotaxic Registration Model'
 
     """
+    if TF_LAYOUT is None:
+        from bids import __version__
+        raise RuntimeError(f"A layout with PyBIDS <{__version__}> could not be initiated")
 
     tf_home = Path(TF_LAYOUT.root)
     filepath = tf_home / ("tpl-%s" % template) / "template_description.json"

--- a/templateflow/conf/__init__.py
+++ b/templateflow/conf/__init__.py
@@ -2,6 +2,7 @@
 from os import getenv
 from warnings import warn
 from pathlib import Path
+from contextlib import suppress
 
 TF_DEFAULT_HOME = Path.home() / ".cache" / "templateflow"
 TF_HOME = Path(getenv("TEMPLATEFLOW_HOME", str(TF_DEFAULT_HOME)))
@@ -87,7 +88,7 @@ TF_LAYOUT = None
 
 
 def init_layout():
-    from .bids import Layout
+    from templateflow.conf.bids import Layout
     from bids.layout.index import BIDSLayoutIndexer
 
     global TF_LAYOUT
@@ -109,7 +110,5 @@ def init_layout():
     )
 
 
-try:
+with suppress(ImportError):
     init_layout()
-except ImportError:
-    pass


### PR DESCRIPTION
We had to dismiss the ``ImportError`` to allow the update/dowonload of the TemplateFlow home skeleton at installation time, which made our unit test pass - but created this problem down the line.

Resolves: #71.