### PR TITLE
Add use_scm_version=True to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,4 +4,4 @@ from setuptools import setup
 
 if __name__ == "__main__":
     """ Install entry-point """
-    setup()
+    setup(use_scm_version=True)


### PR DESCRIPTION
Fixes #67

Alternatively the setup.py could be removed but this requires further testing if setup.cfg is still handled correctly or have to be moved into pyproject.toml