### PR TITLE
ENH: Allow access to PyBIDS' magic ``get_*``

### DIFF
--- a/templateflow/api.py
+++ b/templateflow/api.py
@@ -1,7 +1,8 @@
 """TemplateFlow's Python Client."""
+import sys
+from importlib import import_module
 from json import loads
 from pathlib import Path
-import sys
 from bids.layout import Query
 
 from .conf import TF_LAYOUT, TF_S3_ROOT, TF_USE_DATALAD, requires_layout
@@ -247,6 +248,16 @@ def get_citations(template, bibtex=False):
         return refs
 
     return [_to_bibtex(ref, template, idx).rstrip() for idx, ref in enumerate(refs, 1)]
+
+
+@requires_layout
+def __getattr__(key: str):
+    key = key.replace("ls_", "get_")
+    if key.startswith("get_") and key not in ("get_metadata", "get_citations"):
+        return TF_LAYOUT.__getattr__(key)
+
+    # Spit out default message if we get this far
+    raise AttributeError(f"module '{__name__}' has no attribute '{key}'")
 
 
 def _datalad_get(filepath):

--- a/templateflow/tests/test_api.py
+++ b/templateflow/tests/test_api.py
@@ -97,3 +97,14 @@ def test_citations(tmp_path, template, urls, fbib, lbib):
     else:
         # no citations currently
         assert False
+
+
+def test_pybids_magic_get():
+    """Check automatic entity expansion of the layout."""
+    assert sorted(api.ls_atlases()) == sorted(api.TF_LAYOUT.get_atlases())
+    assert sorted(api.ls_atlases(template="MNI152NLin6ASym")) == sorted(
+        api.TF_LAYOUT.get_atlases(template="MNI152NLin6ASym")
+    )
+
+    with pytest.raises(TypeError):
+        api.ls_atlases("MNI152NLin6ASym")


### PR DESCRIPTION
This patch allows users to access the automated querying of the layout with the ``get_*`` magic (and ``ls_*``, for TF), e.g.:

```Python
>>> from templateflow import api
>>> api.ls_atlases(template="MNI152NLin6Asym")
['DiFuMo', 'Schaefer2018', 'HOCPA', 'HCP', 'HOCPAL', 'HOSPA']
```

The existing ``get_*`` methods are not overshadowed:

```Python
>>> api.get_citations(template="MNI152NLin6Asym")
['https://doi.org/10.1016/j.neuroimage.2012.01.024',
 'https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Atlases']
```

The original ``get_*`` queries are accepted:
```Python
>>> api.get_atlases()
['AAL',
 'DiFuMo',
 'v3',
 'CerebrA',
 'D99',
 'WHS',
 'VALiDATe',
 'v4',
 'Schaefer2018',
 'HOCPA',
 'HCP',
 'CerebA',
 'CCFv3',
 'CHARM',
 'HOCPAL',
 'SARM',
 'HOSPA']
```

I'm hesitant about whether we should disallow ``get_*`` (as the meaning for TF is "fetch it" instead of getting from a table).

WDYT?