### PR TITLE
REL: 23.0.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,15 @@
+0.9.0 (January 30, 2023)
+========================
+Minor release including additional API features and an updated skeleton.
+
+* FIX: Preempt ``BIDSLayout`` from indexing dot-folders (#99)
+* ENH: Make sure existing ``layout.get_*`` are not bubbled in (#102)
+* ENH: Allow access to PyBIDS' magic ``get_*`` (#101)
+* ENH: Add an ``api.ls()`` function to list (without getting) files (#97)
+* MAINT: Discontinue legacy docker runners of CircleCI (#104)
+* MAINT: Rotate CircleCI secrets and setup up org-level context (#103)
+* MAINT: Fix docs build environment in CircleCI (#96)
+
 0.8.1 (May 7, 2022)
 ===================
 Patch release updating the S3 skeleton to include the fixed version of ``tpl-MouseIn``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools >= 45",
     "setuptools_scm >= 6.2",
-    "wheel"
+    "nipreps-versions",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -13,3 +13,4 @@ write_to_template = """\
 __version__ = "{version}"
 """
 fallback_version = "0.0"
+version_scheme = "nipreps-calver"

--- a/update_changes.sh
+++ b/update_changes.sh
@@ -19,8 +19,28 @@ if [[ "$UPCOMING" == "0" ]]; then
     head -n3  CHANGES.rst >> newchanges
 fi
 
+# Elaborate today's release header
+HEADER="$1 ($(date '+%B %d, %Y'))"
+echo $HEADER >> newchanges
+echo $( printf "%${#HEADER}s" | tr " " "=" ) >> newchanges
+echo "" >> newchanges
+
 # Search for PRs since previous release
-git show --pretty='format:  * %b %s'  HEAD | sed 's/Merge pull request \#\([^\d]*\)\ from\ .*/(\#\1)/' >> newchanges
+MERGE_COMMITS=$( git log --grep="Merge pull request\|(#.*)$" `git describe --tags --abbrev=0`..HEAD --pretty='format:%h' )
+for COMMIT in ${MERGE_COMMITS//\n}; do
+    SUB=$( git log -n 1 --pretty="format:%s" $COMMIT )
+    if ( echo $SUB | grep "^Merge pull request" ); then
+        # Merge commit
+        PR=$( echo $SUB | sed -e "s/Merge pull request \#\([0-9]*\).*/\1/" )
+        TITLE=$( git log -n 1 --pretty="format:%b" $COMMIT )
+    else
+        # Squashed merge
+        PR=$( echo $SUB | sed -e "s/.*(\#\([0-9]*\))$/\1/" )
+        TITLE=$( echo $SUB | sed -e "s/\(.*\) (\#[0-9]*)$/\1/" )
+    fi
+    echo "* $TITLE (#$PR)" >> newchanges
+done
+echo >> newchanges
 
 # Add back the Upcoming header if it was present
 if [[ "$UPCOMING" == "0" ]]; then
@@ -31,4 +51,3 @@ fi
 
 # Replace old CHANGES.rst with new file
 mv newchanges CHANGES.rst
-


### PR DESCRIPTION
The `update_changes.sh` script was a bit out of date, but otherwise this looks in decent shape.

@oesteban the API changes seem to justify a new minor release. I see in the release notes we at one point intended to switch to calver:

https://github.com/templateflow/python-client/blob/dd08432566c6acbdba20b98048606c6b054e67de/CHANGES.rst#L63

Should this be 23.0.0 instead? If you like I can update the build to use the nipreps-calver version scheme.