### PR TITLE
FIX: Use Path.as_posix() and f-strinigs to build correct URLs on Windows

### DIFF
--- a/templateflow/api.py
+++ b/templateflow/api.py
@@ -291,8 +291,8 @@ def _s3_get(filepath):
     from tqdm import tqdm
     import requests
 
-    path = str(filepath.relative_to(TF_LAYOUT.root))
-    url = "%s/%s" % (TF_S3_ROOT, path.replace("\\", "/"))
+    path = filepath.relative_to(TF_LAYOUT.root).as_posix()
+    url = f"{TF_S3_ROOT}/{path}"
 
     print("Downloading %s" % url, file=stderr)
     # Streaming, so we can iterate over the response.

--- a/templateflow/api.py
+++ b/templateflow/api.py
@@ -292,7 +292,7 @@ def _s3_get(filepath):
     import requests
 
     path = str(filepath.relative_to(TF_LAYOUT.root))
-    url = "%s/%s" % (TF_S3_ROOT, path)
+    url = "%s/%s" % (TF_S3_ROOT, path.replace("\\", "/"))
 
     print("Downloading %s" % url, file=stderr)
     # Streaming, so we can iterate over the response.


### PR DESCRIPTION
Replace backslashes with forward slashes in all paths. This should create correct https urls from broken windows paths, and should not affect paths from other systems.