### PR TITLE
ENH: Add `seg-<label>` and `scale-<number>` entities

### DIFF
--- a/templateflow/conf/config.json
+++ b/templateflow/conf/config.json
@@ -27,6 +27,14 @@
             "pattern": "[_/\\\\]atlas-([a-zA-Z0-9]+)"
         },
         {
+            "name": "segmentation",
+            "pattern": "[_/\\\\]seg-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "scale",
+            "pattern": "[_/\\\\]scale-([0-9]+)"
+        },
+        {
             "name": "roi",
             "pattern": "[_/\\\\]roi-([a-zA-Z0-9]+)"
         },


### PR DESCRIPTION
Necessary after converting the annots of fsaverage (see templateflow/tpl-fsaverage#5).