### PR TITLE
MAINT: Revise failing Pypi deployment and ``twine check``

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,14 @@ jobs:
             - "/tmp/venv"
 
       - run:
+          name: Test packaging
+          command: |
+            source /tmp/venv/bin/activate
+            cd /tmp/src/templateflow
+            python -m build
+            python -m twine check dist/*
+
+      - run:
           name: Run tests (w/ DataLad)
           command: |
             source /tmp/venv/bin/activate
@@ -119,14 +127,6 @@ jobs:
 
       - store_test_results:
           path: /tmp/tests
-
-      - run:
-          name: Test packaging
-          command: |
-            source /tmp/venv/bin/activate
-            cd /tmp/src/templateflow
-            python -m build
-            python -m twine check dist/*
 
   build_docs:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   tests:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.11
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PAT
@@ -20,18 +20,18 @@ jobs:
 
       - restore_cache:
           keys:
-            - deps-v10-{{ checksum "/tmp/src/templateflow/dev-requirements.txt"}}-{{ epoch }}
-            - deps-v10-{{ checksum "/tmp/src/templateflow/dev-requirements.txt"}}-
-            - deps-v10-
+            - deps-v11-{{ checksum "/tmp/src/templateflow/dev-requirements.txt"}}-{{ epoch }}
+            - deps-v11-{{ checksum "/tmp/src/templateflow/dev-requirements.txt"}}-
+            - deps-v11-
       - run:
           name: Prepare environment
           command: |
             python -m venv /tmp/venv
             source /tmp/venv/bin/activate
-            pip install -U pip
-            pip install -r /tmp/src/templateflow/dev-requirements.txt
-            pip install datalad
-            pip install -U build hatch hatchling nipreps-versions build twine codecov
+            python -m pip install -U pip
+            python -m pip install -r /tmp/src/templateflow/dev-requirements.txt
+            python -m pip install datalad
+            python -m pip install -U build hatch twine pkginfo codecov
 
       - run:
           name: Install git and git-annex
@@ -50,7 +50,7 @@ jobs:
             git config --global user.email "email@domain.com"
 
       - save_cache:
-          key: deps-v10-{{ checksum "/tmp/src/templateflow/requirements.txt"}}-{{ epoch }}
+          key: deps-v11-{{ checksum "/tmp/src/templateflow/dev-requirements.txt"}}-{{ epoch }}
           paths:
             - "/tmp/cache"
             - "/tmp/venv"
@@ -126,7 +126,7 @@ jobs:
             source /tmp/venv/bin/activate
             cd /tmp/src/templateflow
             python -m build
-            twine check dist/*
+            python -m twine check dist/*
 
   build_docs:
     machine:
@@ -190,20 +190,25 @@ jobs:
       - checkout:
           path: /tmp/src/templateflow
 
+      - run:
+          name: Generate requirements.txt
+          command: |
+            python /tmp/src/templateflow/.maint/update_requirements.py
+
       - restore_cache:
           keys:
-            - deps-v10-{{ checksum "/tmp/src/templateflow/requirements.txt"}}-{{ epoch }}
-            - deps-v10-{{ checksum "/tmp/src/templateflow/requirements.txt"}}-
-            - deps-v10-
+            - deps-v11-{{ checksum "/tmp/src/templateflow/dev-requirements.txt"}}-{{ epoch }}
+            - deps-v11-{{ checksum "/tmp/src/templateflow/dev-requirements.txt"}}-
+            - deps-v11-
 
       - run:
           name: Deploy to PyPi
           command: |
             source /tmp/venv/bin/activate
-            pip install build twine
+            python -m pip install build -U twine pkginfo
             python -m build
-            twine check dist/*
-            twine upload dist/*
+            python -m twine check dist/*
+            python -m twine upload dist/*
 
 workflows:
   version: 2

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           python -m venv /tmp/buildenv
           source /tmp/buildenv/bin/activate
-          python -m pip install -U build hatch hatchling nipreps-versions
+          python -m pip install -U build hatch
           if [[ "$GITHUB_REF" == refs/tags/* ]]; then
             TAG=${GITHUB_REF##*/}
           fi


### PR DESCRIPTION
Resolves: #126.

Seems like ``pkginfo`` requires to be >1.9 so that ``twine check`` does not fail.