### PR TITLE
fix(cli): Fix crash in templateflow get when matching one file

### DIFF
--- a/templateflow/cli.py
+++ b/templateflow/cli.py
@@ -141,7 +141,9 @@ def ls(template, **kwargs):
 def get(template, **kwargs):
     """Fetch the assets corresponding to template and optional filters."""
     entities = {k: _nulls(v) for k, v in kwargs.items() if v != ''}
-    click.echo('\n'.join(f'{match}' for match in api.get(template, **entities)))
+    paths = api.get(template, **entities)
+    filenames = [str(paths)] if isinstance(paths, Path) else [str(file) for file in paths]
+    click.echo('\n'.join(filenames))
 
 
 if __name__ == '__main__':

--- a/templateflow/tests/test_cli.py
+++ b/templateflow/tests/test_cli.py
@@ -11,7 +11,7 @@ def test_ls_one():
     result = runner.invoke(cli.main, ['ls', 'MNI152Lin', '--res', '1', '-s', 'T1w'])
 
     # One result
-    lines = result.output.strip().splitlines()
+    lines = result.stdout.strip().splitlines()
     assert len(lines) == 1
 
     assert 'tpl-MNI152Lin/tpl-MNI152Lin_res-01_T1w.nii.gz' in lines[0]
@@ -27,7 +27,7 @@ def test_ls_multi():
     result = runner.invoke(cli.main, ['ls', 'MNI152Lin', '--res', '1', '-s', 'T1w', '-s', 'T2w'])
 
     # Two results
-    lines = result.output.strip().splitlines()
+    lines = result.stdout.strip().splitlines()
     assert len(lines) == 2
 
     assert 'tpl-MNI152Lin/tpl-MNI152Lin_res-01_T1w.nii.gz' in lines[0]
@@ -44,10 +44,7 @@ def test_get_one():
     result = runner.invoke(cli.main, ['get', 'MNI152Lin', '--res', '1', '-s', 'T1w'])
 
     # One result, possible download status before
-    lines = result.output.strip().splitlines()[-2:]
-    if len(lines) == 2:
-        assert lines[0].startswith('100%')
-        lines.pop(0)
+    lines = result.stdout.strip().splitlines()[-2:]
 
     assert 'tpl-MNI152Lin/tpl-MNI152Lin_res-01_T1w.nii.gz' in lines[0]
 
@@ -63,10 +60,7 @@ def test_get_multi():
     result = runner.invoke(cli.main, ['get', 'MNI152Lin', '--res', '1', '-s', 'T1w', '-s', 'T2w'])
 
     # Two result, possible download status before
-    lines = result.output.strip().splitlines()[-3:]
-    if len(lines) == 3:
-        assert lines[0].startswith('100%')
-        lines.pop(0)
+    lines = result.stdout.strip().splitlines()[-3:]
 
     assert 'tpl-MNI152Lin/tpl-MNI152Lin_res-01_T1w.nii.gz' in lines[0]
     assert 'tpl-MNI152Lin/tpl-MNI152Lin_res-01_T2w.nii.gz' in lines[1]

--- a/templateflow/tests/test_cli.py
+++ b/templateflow/tests/test_cli.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+
+import click.testing
+
+from .. import cli
+
+
+def test_ls_one():
+    runner = click.testing.CliRunner()
+
+    result = runner.invoke(cli.main, ['ls', 'MNI152Lin', '--res', '1', '-s', 'T1w'])
+
+    # One result
+    lines = result.output.strip().splitlines()
+    assert len(lines) == 1
+
+    assert 'tpl-MNI152Lin/tpl-MNI152Lin_res-01_T1w.nii.gz' in lines[0]
+
+    path = Path(lines[0])
+
+    assert path.exists()
+
+
+def test_ls_multi():
+    runner = click.testing.CliRunner()
+
+    result = runner.invoke(cli.main, ['ls', 'MNI152Lin', '--res', '1', '-s', 'T1w', '-s', 'T2w'])
+
+    # Two results
+    lines = result.output.strip().splitlines()
+    assert len(lines) == 2
+
+    assert 'tpl-MNI152Lin/tpl-MNI152Lin_res-01_T1w.nii.gz' in lines[0]
+    assert 'tpl-MNI152Lin/tpl-MNI152Lin_res-01_T2w.nii.gz' in lines[1]
+
+    paths = [Path(line) for line in lines]
+
+    assert all(path.exists() for path in paths)
+
+
+def test_get_one():
+    runner = click.testing.CliRunner()
+
+    result = runner.invoke(cli.main, ['get', 'MNI152Lin', '--res', '1', '-s', 'T1w'])
+
+    # One result, possible download status before
+    lines = result.output.strip().splitlines()[-2:]
+    if len(lines) == 2:
+        assert lines[0].startswith('100%')
+        lines.pop(0)
+
+    assert 'tpl-MNI152Lin/tpl-MNI152Lin_res-01_T1w.nii.gz' in lines[0]
+
+    path = Path(lines[0])
+
+    stat_res = path.stat()
+    assert stat_res.st_size == 10669511
+
+
+def test_get_multi():
+    runner = click.testing.CliRunner()
+
+    result = runner.invoke(cli.main, ['get', 'MNI152Lin', '--res', '1', '-s', 'T1w', '-s', 'T2w'])
+
+    # Two result, possible download status before
+    lines = result.output.strip().splitlines()[-3:]
+    if len(lines) == 3:
+        assert lines[0].startswith('100%')
+        lines.pop(0)
+
+    assert 'tpl-MNI152Lin/tpl-MNI152Lin_res-01_T1w.nii.gz' in lines[0]
+    assert 'tpl-MNI152Lin/tpl-MNI152Lin_res-01_T2w.nii.gz' in lines[1]
+
+    paths = [Path(line) for line in lines]
+
+    stats = [path.stat() for path in paths]
+    assert [stat_res.st_size for stat_res in stats] == [10669511, 10096230]

--- a/templateflow/tests/test_cli.py
+++ b/templateflow/tests/test_cli.py
@@ -1,13 +1,17 @@
 from pathlib import Path
 
 import click.testing
+import pytest
 
 from .. import cli
 
 
-def test_ls_one():
-    runner = click.testing.CliRunner()
+@pytest.fixture
+def runner():
+    return click.testing.CliRunner()
 
+
+def test_ls_one(runner):
     result = runner.invoke(cli.main, ['ls', 'MNI152Lin', '--res', '1', '-s', 'T1w'])
 
     # One result
@@ -21,9 +25,7 @@ def test_ls_one():
     assert path.exists()
 
 
-def test_ls_multi():
-    runner = click.testing.CliRunner()
-
+def test_ls_multi(runner):
     result = runner.invoke(cli.main, ['ls', 'MNI152Lin', '--res', '1', '-s', 'T1w', '-s', 'T2w'])
 
     # Two results
@@ -38,9 +40,7 @@ def test_ls_multi():
     assert all(path.exists() for path in paths)
 
 
-def test_get_one():
-    runner = click.testing.CliRunner()
-
+def test_get_one(runner):
     result = runner.invoke(cli.main, ['get', 'MNI152Lin', '--res', '1', '-s', 'T1w'])
 
     # One result, possible download status before
@@ -54,9 +54,7 @@ def test_get_one():
     assert stat_res.st_size == 10669511
 
 
-def test_get_multi():
-    runner = click.testing.CliRunner()
-
+def test_get_multi(runner):
     result = runner.invoke(cli.main, ['get', 'MNI152Lin', '--res', '1', '-s', 'T1w', '-s', 'T2w'])
 
     # Two result, possible download status before


### PR DESCRIPTION
Currently:

```
❯ uvx templateflow get MNI152NLin6Asym --res 2 --desc LR -s T1w
Traceback (most recent call last):
  File "/home/chris/.cache/uv/archive-v0/N20Na8Y61YObB3kT5W_Jk/bin/templateflow", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/chris/.cache/uv/archive-v0/N20Na8Y61YObB3kT5W_Jk/lib/python3.13/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/chris/.cache/uv/archive-v0/N20Na8Y61YObB3kT5W_Jk/lib/python3.13/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/home/chris/.cache/uv/archive-v0/N20Na8Y61YObB3kT5W_Jk/lib/python3.13/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/home/chris/.cache/uv/archive-v0/N20Na8Y61YObB3kT5W_Jk/lib/python3.13/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/chris/.cache/uv/archive-v0/N20Na8Y61YObB3kT5W_Jk/lib/python3.13/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/home/chris/.cache/uv/archive-v0/N20Na8Y61YObB3kT5W_Jk/lib/python3.13/site-packages/templateflow/cli.py", line 144, in get
    click.echo('\n'.join(f'{match}' for match in api.get(template, **entities)))
                                                 ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'PosixPath' object is not iterable
```