### PR TITLE
Allow plus signs in 'to' and 'from' entities

### DIFF
--- a/templateflow/conf/config.json
+++ b/templateflow/conf/config.json
@@ -52,11 +52,11 @@
         },
         {
             "name": "from",
-            "pattern": "(?:^|_)from-([a-zA-Z0-9]+).*xfm"
+            "pattern": "(?:^|_)from-([a-zA-Z0-9+]+).*xfm"
         },
         {
             "name": "to",
-            "pattern": "(?:^|_)to-([a-zA-Z0-9]+).*xfm"
+            "pattern": "(?:^|_)to-([a-zA-Z0-9+]+).*xfm"
         },
         {
             "name": "mode",


### PR DESCRIPTION
Closes #145.

I checked the following:

Before
```python
import templateflow

print(templateflow.__version__)
# 25.0.1

print(len(templateflow.api.get('MNI152NLin6Asym', **{'from': 'MNIInfant', 'suffix': 'xfm'})))
# 11 (all of the cohort-specific MNIInfant transforms)

print(len(templateflow.api.get('MNI152NLin6Asym', **{'from': 'MNIInfant+10', 'suffix': 'xfm'})))
# 0 (no transforms collected)
```

After
```python
import templateflow

print(templateflow.__version__)
# 25.1.0.dev2+g2ee563748

print(len(templateflow.api.get('MNI152NLin6Asym', **{'from': 'MNIInfant', 'suffix': 'xfm'})))
# 0 (no transforms collected)

print(templateflow.api.get('MNI152NLin6Asym', **{'from': 'MNIInfant+10', 'suffix': 'xfm'}))
# .../.cache/templateflow/tpl-MNI152NLin6Asym/tpl-MNI152NLin6Asym_from-MNIInfant+10_mode-image_xfm.h5
```